### PR TITLE
Fix 'Cannot find ffprobe' error

### DIFF
--- a/packages/ffcreator/docs/qa/qa.md
+++ b/packages/ffcreator/docs/qa/qa.md
@@ -137,3 +137,5 @@ Error: Cannot find ffprobe
 #### 解决
 
 项目初始化时设置ffmpeg及ffprobe的路径，`FFCreator.setFFPath();`。
+
+在项目初始化时调用 `FFCreator.setFFPath()` 函数来设置 `ffmpeg` 和 `ffprobe` 的路径。该函数使用 `ffmpegInstaller.path` 和 `ffprobeInstaller.path` 来设置这两个路径。

--- a/packages/ffcreator/lib/utils/ffmpeg.js
+++ b/packages/ffcreator/lib/utils/ffmpeg.js
@@ -38,6 +38,7 @@ const FFmpegUtil = {
    */
   setFFmpegPath(path) {
     ffmpeg.setFfmpegPath(path);
+    this.setFFPath();
   },
 
   /**


### PR DESCRIPTION
Resolve the 'Cannot find ffprobe' error by setting the `ffprobe` path during project initialization.

* Modify `packages/ffcreator/lib/utils/ffmpeg.js` to call `setFFPath()` in the `setFFmpegPath` function to set both `ffmpeg` and `ffprobe` paths.
* Update `packages/ffcreator/docs/qa/qa.md` to include instructions to call `FFCreator.setFFPath()` during project initialization to set the paths for `ffmpeg` and `ffprobe`.

